### PR TITLE
Fix misspelled elasticsearch labels #8916

### DIFF
--- a/lib/Search/UI/SearchThrowableHandler.php
+++ b/lib/Search/UI/SearchThrowableHandler.php
@@ -116,15 +116,15 @@ class SearchThrowableHandler
             case SearchUserFriendlyException::class:
                 return $this->throwable->getMessage();
             case SearchInvalidRequestException::class:
-                return $mod_strings['LBL_ELASTIC_SEARCH_SEARCH_INVALID_REQUEST'];
+                return $mod_strings['LBL_ELASTIC_SEARCH_EXCEPTION_SEARCH_INVALID_REQUEST'];
             case SearchEngineNotFoundException::class:
-                return $mod_strings['LBL_ELASTIC_SEARCH_SEARCH_ENGINE_NOT_FOUND'];
+                return $mod_strings['LBL_ELASTIC_SEARCH_EXCEPTION_SEARCH_ENGINE_NOT_FOUND'];
             case NoNodesAvailableException::class:
-                return $mod_strings['LBL_ELASTIC_SEARCH_NO_NODES_AVAILABLE'];
+                return $mod_strings['LBL_ELASTIC_SEARCH_EXCEPTION_NO_NODES_AVAILABLE'];
             case SearchException::class:
-                return $mod_strings['LBL_ELASTIC_SEARCH_SEARCH'];
+                return $mod_strings['LBL_ELASTIC_SEARCH_EXCEPTION_SEARCH'];
             default:
-                return $mod_strings['LBL_ELASTIC_SEARCH_DEFAULT'];
+                return $mod_strings['LBL_ELASTIC_SEARCH_EXCEPTION_DEFAULT'];
         }
     }
 


### PR DESCRIPTION
Fix for Issue #8916 Misspelled labels in SearchThrowableHandler

## Description
Fix the misspellings in SearchThrowableHandler, where labels are missing "_EXCEPTION".
See #8916
See #8916


## Motivation and Context
See #8916

## How To Test This
Using Elastic search, execute a bad search command `something: named:this`

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->